### PR TITLE
Lock PHP Unit version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - composer install --dev --no-interaction --prefer-source
 
 script:
-  - phpunit --coverage-text --verbose --configuration tests/phpunit.xml
+  - vendor/bin/phpunit --coverage-text --verbose --configuration tests/phpunit.xml
 
 after_script:
   - vendor/bin/test-reporter

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.6.0"
     },
     "require-dev": {
-        "codeclimate/php-test-reporter": "dev-master"
+        "codeclimate/php-test-reporter": "dev-master",
+        "phpunit/phpunit": "^5.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Added PHP unit 5.6 to composer. The tests ran fine, so it appears no upgrades are needed
- Updated build file to use the vendor phpunit to lock in the version.

Ref conversation in Issue #1 
