### PR TITLE
Update private method and add test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - composer install --dev --no-interaction --prefer-source
 
 script:
-  - phpdbg -qrr vendor/bin/phpunit --coverage-text --verbose --configuration tests/phpunit.xml
+  - vendor/bin/phpunit --coverage-text --verbose --configuration tests/phpunit.xml
 
 after_script:
   - vendor/bin/test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - composer install --dev --no-interaction --prefer-source
 
 script:
-  - vendor/bin/phpunit --coverage-text --verbose --configuration tests/phpunit.xml
+  - phpdbg -qrr vendor/bin/phpunit --coverage-text --verbose --configuration tests/phpunit.xml
 
 after_script:
   - vendor/bin/test-reporter

--- a/src/Traits/Chainable.php
+++ b/src/Traits/Chainable.php
@@ -20,18 +20,22 @@ trait Chainable
       return new static;
     }
 
-    private function methodCallable($object=null, $method=null) {
-        if (is_null($object)) {
-            throw new \Exception('Chainable subject has not been provided.');
-        }
+    /**
+     * @param mixed $object
+     * @param string $method
+     * @return bool
+     * @throws \Exception
+     */
+    private function methodCallable($object, $method) {
         if (!is_object($object)) {
             throw new \Exception('Chainable subject is not an object.');
         }
 
         $class = get_class($object);
 
-        if (is_null($method)) {
-            throw new \Exception("Chainable method not provided for object {$class}.");
+        if (!is_string($method)) {
+            $type = gettype($method);
+            throw new \Exception("Chainable method name must be a string. {$type} was provided for object {$class}.");
         }
         if (!method_exists($object, $method)) {
             throw new \Exception("Chainable method does not exist on object {$class}.");

--- a/tests/ChainableTest.php
+++ b/tests/ChainableTest.php
@@ -16,6 +16,32 @@ class ChainableTest extends PHPUnit_Framework_TestCase {
 	 function test_missing_method() {
 		$sandwich = Sandwich::addBananas()->run();
 	}
+
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage Chainable subject is not an object
+	 */
+	public function test_method_called_on_non_object_throws_exception(){
+		$sandwich = new Sandwich();
+		$reflection = new ReflectionObject($sandwich);
+		$method = $reflection->getMethod('methodCallable');
+		$method->setAccessible(true);
+		$method->invokeArgs($sandwich, [1, 'method']);
+	}
+
+
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage Chainable method name must be a string. integer was provided for object Skybluesofa\Chainable\Tests\Sandwich.
+	 */
+	public function test_method_called_with_non_string_method_name_throws_exception(){
+		$sandwich = new Sandwich();
+		$reflection = new ReflectionObject($sandwich);
+		$method = $reflection->getMethod('methodCallable');
+		$method->setAccessible(true);
+		$method->invokeArgs($sandwich, [$sandwich, 5]);
+	}
+
 	function test_peanut_butter_and_jelly() {
 		$sandwich = Sandwich::withBread('white')->addCondiment('peanut butter')->addCondiment('jelly')->make();
 		$this->assertEquals('white', $sandwich['bread']);


### PR DESCRIPTION
- We can remove the is_null checks by not allowing null in the signature
- The unit ensure we can't accidentally use this private method in an
  invalid way.

Refs #1
